### PR TITLE
Update PT-BR Language + Fix quotation mark missing

### DIFF
--- a/language/PT-BR/Items.txt
+++ b/language/PT-BR/Items.txt
@@ -7,7 +7,7 @@
 	"ITEM_CRITGLASSES_PICKUP_RISKYMOD": "Ganhe 7% de chance de causar Acerto Crítico ao golpear, causando dano em dobro.",
 	"ITEM_CRITGLASSES_DESC_RISKYMOD": "Seus ataques têm <style=cIsDamage>7%</style> <style=cStack>(+7% por acúmulo)</style> de chance de realizar um \'<style=cIsDamage>Acerto Crítico</style>\', causando <style=cIsDamage>dano dobrado</style>.",
   
-	"ITEM_STICKYBOMB_DESC_RISKYMOD": "<style=cIsDamage>5%</style> <style=cStack>(+5% por acúmulo)</style> ao golpear, de colocar uma <style=cIsDamage>bomba</style> m um inimigo, que ao detonar causa <style=cIsDamage>240%</style> de dano TOTAL.",
+	"ITEM_STICKYBOMB_DESC_RISKYMOD": "<style=cIsDamage>5%</style> <style=cStack>(+5% por acúmulo)</style> de chance ao golpear, de colocar uma <style=cIsDamage>bomba</style> em um inimigo, que ao detonar causa <style=cIsDamage>240%</style> de dano TOTAL.",
 
 	"ITEM_CROWBAR_PICKUP_RISKYMOD": "Cause dano bônus ao atingir o inimigo pela primeira vez.",
 	"ITEM_CROWBAR_DESC_RISKYMOD": "Cause <style=cIsDamage>+45%</style> <style=cStack>(+45% por acúmulo)</style> de dano no seu <style=cIsDamage>primeiro golpe</style> contra um inimigo.",
@@ -15,7 +15,7 @@
 	"ITEM_WARDONLEVEL_PICKUP_RISKYMOD": "Solte um Estandarte de Guerra ao subir de nível ou no início de um evento de Teleportador. Concede dano, velocidade de ataque e de movimento, e regeneração de saúde aos aliados.",
 	"ITEM_WARDONLEVEL_DESC_RISKYMOD": "Ao <style=cIsUtility>subir de nível</style> ou iniciar o <style=cIsUtility>evento de Teleportador</style>, solte um estandarte que fortalece todos os aliados dentro de <style=cIsUtility>16 m</style> <style=cStack>(+8 m por acúmulo)</style>. Aumenta o <style=cIsDamage>dano</style> em <style=cIsDamage>15%</style>, e a <style=cIsDamage>velocidade de ataque</style> e <style=cIsUtility>de movimento</style> em <style=cIsDamage>30%</style>. Regenera <style=cIsHealing>1%</style> de sua <style=cIsHealing>saúde</style> a cada segundo.",  
 
-	"ITEM_IGNITEONKILL_DESC_RISKYMOD": "Abater um inimigo <style=cIsDamage>incendeia</style>  todos os inimigos em um raio de <style=cIsDamage>12 m</style>, causando <style=cIsDamage>150%</style> de dano base. Além disso, os inimigos <style=cIsDamage>queimam</style>, recebendo <style=cIsDamage>150%</style> <style=cStack>(+75% por acúmulo)</style> de dano base.",  
+	"ITEM_IGNITEONKILL_DESC_RISKYMOD": "Abater um inimigo <style=cIsDamage>incendeia</style> todos os inimigos em um raio de <style=cIsDamage>12 m</style>, causando <style=cIsDamage>150%</style> de dano base. Além disso, os inimigos <style=cIsDamage>queimam</style>, recebendo <style=cIsDamage>150%</style> <style=cStack>(+75% por acúmulo)</style> de dano base.",  
 
 	"ITEM_REPULSIONARMORPLATE_PICKUP_RISKYMOD": "Aumenta a armadura em 5.",
 	"ITEM_REPULSIONARMORPLATE_DESC_RISKYMOD": "<style=cIsHealing>Aumenta a armadura</style> em <style=cIsHealing>5</style>.",
@@ -60,7 +60,7 @@
 	"ITEM_ENERGIZEDONEQUIPMENTUSE_DESC_RISKYMOD": "Ativar seu Equipamento concede <style=cIsUtility>+50% de velocidade de movimento</style> e <style=cIsDamage>+70% de velocidade de ataque</style> por <style=cIsDamage>8 s</style> <style=cStack>(+4 s por acúmulo)</style>.",
 
 	"ITEM_INFUSION_PICKUP_RISKYMOD": "Abater um inimigo aumenta permanentemente sua saúde máxima.",
-	"ITEM_INFUSION_DESC_RISKYMOD": "Abater um inimigo aumenta <style=cIsHealing>permanentemente sua saúde</style> em <style=cIsHealing>1</style> <style=cStack>(+1 por acúmulo)</style>. A cada <style=cIsHealing>100 de saúde</style> recebida por este item <style=cIsHealth>reduz</style> a saúde recebida ao abater.",
+	"ITEM_INFUSION_DESC_RISKYMOD": "Abater um inimigo aumenta <style=cIsHealing>permanentemente sua saúde</style> em <style=cIsHealing>1</style> <style=cStack>(+1 por acúmulo)</style>. A cada <style=cIsHealing>100 de saúde</style> recebida por este item, a saúde recebido ao abater é <style=cIsHealth>reduzida</style>.",
 	
 	"ITEM_ICICLE_DESC_RISKYMOD": "Abater um inimigo cria ao seu redor uma <style=cIsDamage>tempestade de gelo</style> que causa <style=cIsDamage>1.200% <style=cStack>(+600% por acúmulo)</style> de dano por segundo</style> e <style=cIsUtility>lentidão</style> de <style=cIsUtility>80%</style> aos inimigos por <style=cIsUtility>1,5 s</style>. A tempestade <style=cIsDamage>aumenta a cada abate</style>, aumentando seu alcance em <style=cIsDamage>3 m</style>. Acumula até <style=cIsDamage>24 m</style>.",
 

--- a/language/PT-BR/Items.txt
+++ b/language/PT-BR/Items.txt
@@ -79,7 +79,7 @@
 	
 	"ITEM_LIGHTNINGSTRIKEONHIT_DESC_RISKYMOD": "<style=cIsDamage>10%</style> de chance, ao golpear, de conjurar um relâmpago, causando <style=cIsDamage>500%</style> <style=cStack>(+300% por acúmulo)</style> de dano.",
 
-	"ITEM_BLEEDONHITANDEXPLODE_PICKUP_RISKYMOD": "Bleeding enemies explode on kill.",
+	"ITEM_BLEEDONHITANDEXPLODE_PICKUP_RISKYMOD": "Inimigos sangrando explodem ao serem abatidos.",
 	"ITEM_BLEEDONHITANDEXPLODE_DESC_RISKYMOD": "Ganha <style=cIsDamage>10%</style> de chance de causar <style=cIsDamage>sangramento</style> aos inimigos, causando <style=cIsDamage>240%</style> de dano base. Inimigos <style=cIsDamage>sangrando</style> <style=cIsDamage>explodem</style> ao serem abatidos, causando <style=cIsDamage>400%</style> <style=cStack>(+320% por acúmulo)</style> de dano, mais <style=cIsDamage>10%</style> <style=cStack>(+8% por acúmulo)</style> da saúde máxima deles.",
 	
 	"ITEM_KNURL_PICKUP_RISKYMOD": "Reforça a saúde, a regeneração e a armadura.",
@@ -131,8 +131,8 @@
 	
 	"ITEM_BEARVOID_DESC_RISKYMOD": "<style=cIsHealing>Bloqueia</style> dano recebido uma vez. Recarrega após <style=cIsUtility>20 segundos</style> <style=cStack>(-10% por acúmulo)</style>. <style=cIsVoid>Corrompe todos os Tempos Difíceis</style>.",
 
-	"ITEM_BARRIERONOVERHEAL_DESC_RISKYMOD": Curar além do limite concede uma <style=cIsHealing>barreira temporária</style> de <style=cIsHealing>50% <style=cStack>(+50% por acúmulo)</style></style> do total <style=cIsHealing>curado</style>. Divide a <style=cIsHealing>taxa de decaimento da barreira</style> em <style=cIsHealing>2 <style=cStack>(+1 por acúmulo)</style></style>.",
+	"ITEM_BARRIERONOVERHEAL_DESC_RISKYMOD": "Curar além do limite concede uma <style=cIsHealing>barreira temporária</style> de <style=cIsHealing>50% <style=cStack>(+50% por acúmulo)</style></style> do total <style=cIsHealing>curado</style>. Divide a <style=cIsHealing>taxa de decaimento da barreira</style> em <style=cIsHealing>2 <style=cStack>(+1 por acúmulo)</style></style>.",
 
-	"ITEM_LUNARDAGGER_DESC_RISKYMOD": "Aumenta o dano base em <style=cIsDamage>100%</style> <style=cStack>(+100% por acúmulo)</style>. <style=cIsHealth>Divide a saúde máxima por 2 </style> <style=cStack>(+1 por acúmulo)</style>.",
+	"ITEM_LUNARDAGGER_DESC_RISKYMOD": "Aumenta o dano base em <style=cIsDamage>100%</style> <style=cStack>(+100% por acúmulo)</style>. <style=cIsHealth>Divide a saúde máxima por 2</style> <style=cStack>(+1 por acúmulo)</style>.",
 	}
 }

--- a/language/PT-BR/Survivors.txt
+++ b/language/PT-BR/Survivors.txt
@@ -60,8 +60,8 @@ Venenoso</style>. Lance uma bile tóxica que causa <style=cIsDamage>240% de dano
 	"CROCO_SECONDARY_ALT_DESCRIPTION_RISKYMOD" : "<color=#B1387F>Praga</color>. <style=cIsDamage>Assassino</style>. <style=cIsHealing>Regenerativo</style>. Morda um inimigo, causando <style=cIsDamage>360% de dano</style>.",
 	"CROCO_UTILITY_DESCRIPTION_RISKYMOD" : "<color=#B1387F>Praga</color>. <style=cIsDamage>Atordoante</style>. Salte no ar, causando <style=cIsDamage>320% de dano</style>. Deixe uma poça de ácido que causa <style=cIsDamage>50% de dano</style>. Pode acumular até <style=cIsUtility>2</style> cargas.",
 	"CROCO_UTILITY_ALT1_DESCRIPTION_RISKYMOD" : "<color=#B1387F>Praga</color>. <style=cIsDamage>Atordoante</style>. Salte no ar, causando <style=cIsDamage>550% de dano</style>. <style=cIsUtility>Reduz</style> o tempo de recarga das habilidades em <style=cIsUtility>1 s</style> para cada inimigo atingido.",
-	"CROCO_SPECIAL_DESCRIPTION_RISKYMOD" : "Release a deadly disease that deals <style=cIsDamage>8x100% damage</style>. The disease spreads to up to <style=cIsDamage>20</style> targets.",
-	"CROCO_SPECIAL_NAME_SCEPTER_RISKYMOD" : "Pandemic",
+	"CROCO_SPECIAL_DESCRIPTION_RISKYMOD" : "Libere uma doença mortal que causa <style=cIsDamage>8x100% de dano</style>. A doença se espalha a até <style=cIsDamage>20</style> alvos.",
+	"CROCO_SPECIAL_NAME_SCEPTER_RISKYMOD" : "Pandêmico",
 	"CROCO_SPECIAL_DESCRIPTION_SCEPTER_RISKYMOD" : "Libere uma doença mortal que causa <style=cIsDamage>15 x 100% de dano</style>.  A doença se espalha a até <style=cIsDamage>20</style> alvos. <style=cIsHealing>Se cure</style> caso o inimigo seja abatido por Pandemia.",
 
 	"MAGE_PRIMARY_FIRE_DESCRIPTION_RISKYMOD" : "<style=cIsDamage>Incendiário</style>. Dispare um raio que causa <style=cIsDamage>360% de dano</style> aos inimigos. Máximo de 4.

--- a/language/PT-BR/Survivors.txt
+++ b/language/PT-BR/Survivors.txt
@@ -45,7 +45,7 @@
 	"TOOLBOT_PRIMARY_ALT1_DESCRIPTION_RISKYMOD" : "Dispare uma barra perfurante que causa <style=cIsDamage>660% de dano</style>.",
 	"TOOLBOT_PRIMARY_ALT2_DESCRIPTION_RISKYMOD" : "Lance um foguete que explode, causando <style=cIsDamage>390% de dano</style>. Máximo de 4.",
 	"TOOLBOT_PRIMARY_ALT3_DESCRIPTION_RISKYMOD" : "Serra os inimigos próximos, causando <style=cIsDamage>1.000% de dano por segundo</style>. Recebe uma <style=cIsHealing>barreira temporária</style> ao atingir inimigos.",
-	"TOOLBOT_SPECIAL_ALT_DESCRIPTION_RISKYMOD" : "Assuma uma postura de combate pesado, equipando seus dois <style=cIsDamage>ataques primários</style> de uma vez. Receba <style=cIsUtility>60 de armadura</style>, as perca <style=cIsHealth>-60% de velocidade de movimento</style>.",
+	"TOOLBOT_SPECIAL_ALT_DESCRIPTION_RISKYMOD" : "Assuma uma postura de combate pesado, equipando seus dois <style=cIsDamage>ataques primários</style> de uma vez. Receba <style=cIsUtility>60 de armadura</style>, mas perca <style=cIsHealth>-60% de velocidade de movimento</style>.",
 	
 	"TREEBOT_UTILITY_DESCRIPTION_RISKYMOD" : "Dispare um <style=cIsUtility>Estrondo Sônico</style> que <style=cIsDamage>Enfraquece</style> inimigos. <style=cIsHealing>Cura para cada alvo atingido</style>.",
 	"TREEBOT_SPECIAL_ALT1_DESCRIPTION_RISKYMOD" : "<style=cIsDamage>Injeta</style> um inimigo para causar <style=cIsDamage>330% de dano</style>. Aliados são <style=cIsHealing>curados</style> em <style=cIsHealing>10%</style> do dano causado aos inimigos <style=cIsDamage>Injetados</style>. Ao abater, derrube <style=cIsHealing>frutas de cura</style> que curam <style=cIsHealing>25% PV</style>.",


### PR DESCRIPTION
Hello Moffein, I fixed a startup error where a quote was missing in one of the items in PT-BR. I also translated an Acrid ability that I ended up forgetting and improve some other things. However, I noticed some small errors that are beyond my ability to fix, so I'm passing them on:

The following skills are not translating:
CROCO_UTILITY_DESCRIPTION_RISKYMOD
CROCO_UTILITY_ALT1_DESCRIPTION_RISKYMOD
CROCO_SECONDARY_ALT_DESCRIPTION_RISKYMOD
MAGE_PRIMARY_LIGHTNING_DESCRIPTION_RISKYMOD
MAGE_PRIMARY_FIRE_DESCRIPTION_RISKYMOD

The following skills are not appearing in PT-BR:
MAGE_SPECIAL_SITHLIGHTNING_NAME_RISKYMOD
MAGE_UTILITY_FIRE_NAME_RISKYMOD

idk if you prefer me to create an 'Issue' or just leave everything here, as I did hahahaha